### PR TITLE
[RELEASE] v1.3.0

### DIFF
--- a/src/RequestBodyValidator.php
+++ b/src/RequestBodyValidator.php
@@ -60,7 +60,7 @@ final class RequestBodyValidator
 
         if ($parsedBody === null || !is_array($parsedBody)) {
             throw new InvalidArgumentException("Only supports parsed body in the forms of array.");
-        }else{
+        } else {
             $this->parsedBody = $parsedBody;
         }
 
@@ -72,7 +72,7 @@ final class RequestBodyValidator
      * them to the user in a nice and likeable way.
      * @return array The fields that did not match their criteria.
      */
-    public function getFieldsWithErrors() : array
+    public function getFieldsWithErrors(): array
     {
         return array_keys($this->errors);
     }
@@ -90,6 +90,7 @@ final class RequestBodyValidator
                 return false;
             }
         }
+
         return true;
     }
 
@@ -128,9 +129,10 @@ final class RequestBodyValidator
                 throw new InvalidArgumentException("Invalid validation '$criteria'.");
             }
 
-            if(!$status){
+            if (!$status) {
                 $this->errors[$field] = $criteria;
             }
+
             return $status;
         } else {
             return false;
@@ -160,9 +162,11 @@ final class RequestBodyValidator
         try {
             return new DateTime($this->parsedBody[$field]);
         } catch (Exception $e) {
-            if($throw){
-                throw new RuntimeException("{$this->parsedBody[$field]} is not a valid date format.", $e->getCode(), $e);
-            }else{
+            if ($throw) {
+                throw new RuntimeException(
+                    "{$this->parsedBody[$field]} is not a valid date format.", $e->getCode(), $e
+                );
+            } else {
                 return null;
             }
         }
@@ -180,9 +184,9 @@ final class RequestBodyValidator
         if ($this->validateOne($field, self::NUMERIC)) {
             return $this->parsedBody[$field];
         } else {
-            if($throw){
+            if ($throw) {
                 throw new RuntimeException("$field does not exist or is not numeric.");
-            }else{
+            } else {
                 return null;
             }
         }
@@ -198,11 +202,11 @@ final class RequestBodyValidator
     public function getInt(string $field, bool $throw = true): ?int
     {
         if ($this->validateOne($field, self::NUMERIC)) {
-            return (int) $this->parsedBody[$field];
+            return (int)$this->parsedBody[$field];
         } else {
-            if($throw){
+            if ($throw) {
                 throw new RuntimeException("$field does not exist or is not numeric.");
-            }else{
+            } else {
                 return null;
             }
         }
@@ -218,11 +222,11 @@ final class RequestBodyValidator
     public function getFloat(string $field, bool $throw = true): ?float
     {
         if ($this->validateOne($field, self::NUMERIC)) {
-            return (float) $this->parsedBody[$field];
+            return (float)$this->parsedBody[$field];
         } else {
-            if($throw){
+            if ($throw) {
                 throw new RuntimeException("$field does not exist or is not numeric.");
-            }else{
+            } else {
                 return null;
             }
         }
@@ -240,9 +244,9 @@ final class RequestBodyValidator
         if ($this->validateOne($field, self::EXISTS)) {
             return (string)$this->parsedBody[$field];
         } else {
-            if($throw){
+            if ($throw) {
                 throw new RuntimeException("$field does not exist.");
-            }else{
+            } else {
                 return null;
             }
         }

--- a/src/RequestBodyValidator.php
+++ b/src/RequestBodyValidator.php
@@ -110,6 +110,7 @@ final class RequestBodyValidator
      * @param mixed $field The name of the field to validate.
      * @param int $criteria The criteria to validate with (see class constants).
      * @param bool $trackErrors Whether to count invalid criteria as error, defaults to false.
+     * @note Empty is considered an empty value, not 0 or a string containing only 0
      * @return bool Whether the criteria was validated.
      */
     private function internalValidate($field, int $criteria, bool $trackErrors = false): bool
@@ -121,21 +122,21 @@ final class RequestBodyValidator
             } elseif ($criteria === self::NOT_EMPTY) {
                 $status =
                     isset($this->parsedBody[$field])
-                    && !empty($this->parsedBody[$field]);
+                    && $this->parsedBody[$field] !== "";
             } elseif ($criteria === self::NUMERIC) {
                 $status =
                     isset($this->parsedBody[$field])
-                    && !empty($this->parsedBody[$field])
+                    && $this->parsedBody[$field] !== ""
                     && is_numeric($this->parsedBody[$field]);
             } elseif ($criteria === self::NOT_NUMERIC) {
                 $status =
                     isset($this->parsedBody[$field])
-                    && !empty($this->parsedBody[$field])
+                    && $this->parsedBody[$field] !== ""
                     && !is_numeric($this->parsedBody[$field]);
             } elseif ($criteria === self::DATE_FORMAT) {
                 $status =
                     isset($this->parsedBody[$field])
-                    && !empty($this->parsedBody[$field])
+                    && $this->parsedBody[$field] !== ""
                     && strtotime($this->parsedBody[$field]) !== false;
             } else {
                 throw new InvalidArgumentException("Invalid validation '$criteria'.");

--- a/src/RequestBodyValidator.php
+++ b/src/RequestBodyValidator.php
@@ -247,4 +247,24 @@ final class RequestBodyValidator
             }
         }
     }
+
+    /**
+     * Retrieves a field as non empty string.
+     * @param string $field The field to retrieve.
+     * @param bool $throw If the field is non-existent or empty, whether to throw or simply return null, defaults to true.
+     * @return string The field value.
+     * @throws \RuntimeException If the field does not exist.
+     */
+    public function getStringNotEmpty(string $field, bool $throw = true): ?string
+    {
+        if ($this->validateOne($field, self::NOT_EMPTY)) {
+            return (string)$this->parsedBody[$field];
+        } else {
+            if ($throw) {
+                throw new RuntimeException("$field is empty or does not exist.");
+            } else {
+                return null;
+            }
+        }
+    }
 }

--- a/src/RequestBodyValidator.php
+++ b/src/RequestBodyValidator.php
@@ -102,6 +102,18 @@ final class RequestBodyValidator
      */
     public function validateOne($field, int $criteria): bool
     {
+        return $this->internalValidate($field, $criteria, true);
+    }
+
+    /**
+     * Internal validator, used to disable error tracking.
+     * @param mixed $field The name of the field to validate.
+     * @param int $criteria The criteria to validate with (see class constants).
+     * @param bool $trackErrors Whether to count invalid criteria as error, defaults to false.
+     * @return bool Whether the criteria was validated.
+     */
+    private function internalValidate($field, int $criteria, bool $trackErrors = false): bool
+    {
         if ($this->parsedBody !== null) {
             if ($criteria === self::EXISTS) {
                 $status =
@@ -129,7 +141,7 @@ final class RequestBodyValidator
                 throw new InvalidArgumentException("Invalid validation '$criteria'.");
             }
 
-            if (!$status) {
+            if (!$status && $trackErrors) {
                 $this->errors[$field] = $criteria;
             }
 
@@ -146,7 +158,7 @@ final class RequestBodyValidator
      */
     public function getSingleCheckboxVal(string $field): bool
     {
-        return $this->validateOne($field, self::EXISTS);
+        return $this->internalValidate($field, self::EXISTS);
     }
 
     /**
@@ -181,7 +193,7 @@ final class RequestBodyValidator
      */
     public function getNumeric(string $field, bool $throw = true)
     {
-        if ($this->validateOne($field, self::NUMERIC)) {
+        if ($this->internalValidate($field, self::NUMERIC)) {
             return $this->parsedBody[$field];
         } else {
             if ($throw) {
@@ -201,7 +213,7 @@ final class RequestBodyValidator
      */
     public function getInt(string $field, bool $throw = true): ?int
     {
-        if ($this->validateOne($field, self::NUMERIC)) {
+        if ($this->internalValidate($field, self::NUMERIC)) {
             return (int)$this->parsedBody[$field];
         } else {
             if ($throw) {
@@ -221,7 +233,7 @@ final class RequestBodyValidator
      */
     public function getFloat(string $field, bool $throw = true): ?float
     {
-        if ($this->validateOne($field, self::NUMERIC)) {
+        if ($this->internalValidate($field, self::NUMERIC)) {
             return (float)$this->parsedBody[$field];
         } else {
             if ($throw) {
@@ -241,7 +253,7 @@ final class RequestBodyValidator
      */
     public function getString(string $field, bool $throw = true): ?string
     {
-        if ($this->validateOne($field, self::EXISTS)) {
+        if ($this->internalValidate($field, self::EXISTS)) {
             return (string)$this->parsedBody[$field];
         } else {
             if ($throw) {
@@ -261,7 +273,7 @@ final class RequestBodyValidator
      */
     public function getStringNotEmpty(string $field, bool $throw = true): ?string
     {
-        if ($this->validateOne($field, self::NOT_EMPTY)) {
+        if ($this->internalValidate($field, self::NOT_EMPTY)) {
             return (string)$this->parsedBody[$field];
         } else {
             if ($throw) {

--- a/src/RequestBodyValidator.php
+++ b/src/RequestBodyValidator.php
@@ -171,16 +171,27 @@ final class RequestBodyValidator
      */
     public function getDateTime(string $field, bool $throw = true): ?DateTime
     {
-        try {
-            return new DateTime($this->parsedBody[$field]);
-        } catch (Exception $e) {
-            if ($throw) {
-                throw new RuntimeException(
-                    "{$this->parsedBody[$field]} is not a valid date format.", $e->getCode(), $e
-                );
-            } else {
-                return null;
+        $previous = null;
+        // We could also use self::DATE_FORMAT, but we loose the chance to output the field value that caused the error
+        if ($this->internalValidate($field, self::NOT_EMPTY)) {
+            try {
+                return new DateTime($this->parsedBody[$field]);
+            } catch (Exception $e) {
+                $previous = $e;
             }
+        }
+
+        if ($throw) {
+            $message = $previous === null
+                ? "$field does not exist."
+                : "{$this->parsedBody[$field]} is not a valid date format.";
+            throw new RuntimeException(
+                $message,
+                $previous !== null ? $previous->getCode() : 0,
+                $previous
+            );
+        } else {
+            return null;
         }
     }
 

--- a/tests/GettersTest.php
+++ b/tests/GettersTest.php
@@ -75,9 +75,19 @@ class GettersTest extends TestCase
 
         $this->assertEquals($datetime, $this->rbv->getDateTime("datetime"));
         $this->assertSame(null, $this->rbv->getDateTime("invalidDatetime", false));
+        $this->assertSame(null, $this->rbv->getDateTime("nonExistantDatetime", false));
 
-        $this->expectExceptionMessage("20203-21 180823 is not a valid date format");
-        $this->rbv->getDateTime("invalidDatetime");
+        try {
+            $this->rbv->getDateTime("invalidDatetime");
+        } catch (Exception $e) {
+            $this->assertEquals("20203-21 180823 is not a valid date format.", $e->getMessage());
+        }
+
+        try {
+            $this->rbv->getDateTime("nonExistantDatetime");
+        } catch (Exception $e) {
+            $this->assertEquals("nonExistantDatetime does not exist.", $e->getMessage());
+        }
     }
 
     /**

--- a/tests/GettersTest.php
+++ b/tests/GettersTest.php
@@ -61,7 +61,7 @@ class GettersTest extends TestCase
     public function errorsRetrievalTest()
     {
         $this->rbv->validateMultiple(["datetime", "invalidDatetime"], RequestBodyValidator::DATE_FORMAT);
-        $this->assertEquals(["invalidDatetime"], $this->rbv->getFieldsWithErrors());
+        $this->assertSame(["invalidDatetime"], $this->rbv->getFieldsWithErrors());
     }
 
     /**
@@ -73,7 +73,7 @@ class GettersTest extends TestCase
         $datetime = new DateTime("2021-03-21 18:08:23");
 
         $this->assertEquals($datetime, $this->rbv->getDateTime("datetime"));
-        $this->assertEquals(null, $this->rbv->getDateTime("invalidDatetime", false));
+        $this->assertSame(null, $this->rbv->getDateTime("invalidDatetime", false));
 
         $this->expectExceptionMessage("20203-21 180823 is not a valid date format");
         $this->rbv->getDateTime("invalidDatetime");
@@ -85,8 +85,8 @@ class GettersTest extends TestCase
      */
     public function getCheckboxValue()
     {
-        $this->assertEquals(true, $this->rbv->getSingleCheckboxVal("checkboxPresent"));
-        $this->assertEquals(false, $this->rbv->getSingleCheckboxVal("waitItDoesNotExist"));
+        $this->assertSame(true, $this->rbv->getSingleCheckboxVal("checkboxPresent"));
+        $this->assertSame(false, $this->rbv->getSingleCheckboxVal("waitItDoesNotExist"));
     }
 
     /**
@@ -95,11 +95,11 @@ class GettersTest extends TestCase
      */
     public function getNumeric()
     {
-        $this->assertEquals("25", $this->rbv->getNumeric("numeric0"));
-        $this->assertEquals("27.5", $this->rbv->getNumeric("numeric1"));
-        $this->assertEquals(1.22, $this->rbv->getNumeric("floating"));
-        $this->assertEquals(36, $this->rbv->getNumeric("integer"));
-        $this->assertEquals(null, $this->rbv->getNumeric("edfiwgjewig", false));
+        $this->assertSame("25", $this->rbv->getNumeric("numeric0"));
+        $this->assertSame("27.5", $this->rbv->getNumeric("numeric1"));
+        $this->assertSame(1.22, $this->rbv->getNumeric("floating"));
+        $this->assertSame(36, $this->rbv->getNumeric("integer"));
+        $this->assertSame(null, $this->rbv->getNumeric("edfiwgjewig", false));
     }
 
     /**
@@ -108,11 +108,11 @@ class GettersTest extends TestCase
      */
     public function getInt()
     {
-        $this->assertEquals(25, $this->rbv->getInt("numeric0"));
-        $this->assertEquals(27, $this->rbv->getInt("numeric1"));
-        $this->assertEquals(1, $this->rbv->getInt("floating"));
-        $this->assertEquals(36, $this->rbv->getInt("integer"));
-        $this->assertEquals(null, $this->rbv->getInt("32zu542", false));
+        $this->assertSame(25, $this->rbv->getInt("numeric0"));
+        $this->assertSame(27, $this->rbv->getInt("numeric1"));
+        $this->assertSame(1, $this->rbv->getInt("floating"));
+        $this->assertSame(36, $this->rbv->getInt("integer"));
+        $this->assertSame(null, $this->rbv->getInt("32zu542", false));
     }
 
     /**
@@ -121,11 +121,11 @@ class GettersTest extends TestCase
      */
     public function getFloat()
     {
-        $this->assertEquals(25.0, $this->rbv->getFloat("numeric0"));
-        $this->assertEquals(27.5, $this->rbv->getFloat("numeric1"));
-        $this->assertEquals(1.22, $this->rbv->getFloat("floating"));
-        $this->assertEquals(36.0, $this->rbv->getFloat("integer"));
-        $this->assertEquals(null, $this->rbv->getFloat("apwqfqow", false));
+        $this->assertSame(25.0, $this->rbv->getFloat("numeric0"));
+        $this->assertSame(27.5, $this->rbv->getFloat("numeric1"));
+        $this->assertSame(1.22, $this->rbv->getFloat("floating"));
+        $this->assertSame(36.0, $this->rbv->getFloat("integer"));
+        $this->assertSame(null, $this->rbv->getFloat("apwqfqow", false));
     }
 
     /**

--- a/tests/GettersTest.php
+++ b/tests/GettersTest.php
@@ -145,7 +145,8 @@ class GettersTest extends TestCase
      * Tests the string not empty getter.
      * @test
      */
-    public function getStringNotEmpty(){
+    public function getStringNotEmpty()
+    {
         $this->assertSame("lorem", $this->rbv->getStringNotEmpty("text"));
         $this->assertSame("27.5", $this->rbv->getStringNotEmpty("numeric1"));
         $this->assertSame("1.22", $this->rbv->getStringNotEmpty("floating"));

--- a/tests/GettersTest.php
+++ b/tests/GettersTest.php
@@ -129,14 +129,26 @@ class GettersTest extends TestCase
     }
 
     /**
-     * Tests the float getter.
+     * Tests the string getter.
      * @test
      */
     public function getString()
     {
-        $this->assertEquals("lorem", $this->rbv->getString("text"));
-        $this->assertEquals("27.5", $this->rbv->getString("numeric1"));
-        $this->assertEquals("1.22", $this->rbv->getString("floating"));
-        $this->assertEquals(null, $this->rbv->getString("qdqf", false));
+        $this->assertSame("lorem", $this->rbv->getString("text"));
+        $this->assertSame("27.5", $this->rbv->getString("numeric1"));
+        $this->assertSame("1.22", $this->rbv->getString("floating"));
+        $this->assertSame("", $this->rbv->getString("empty"));
+        $this->assertSame(null, $this->rbv->getString("qdqf", false));
+    }
+
+    /**
+     * Tests the string not empty getter.
+     * @test
+     */
+    public function getStringNotEmpty(){
+        $this->assertSame("lorem", $this->rbv->getStringNotEmpty("text"));
+        $this->assertSame("27.5", $this->rbv->getStringNotEmpty("numeric1"));
+        $this->assertSame("1.22", $this->rbv->getStringNotEmpty("floating"));
+        $this->assertSame(null, $this->rbv->getStringNotEmpty("empty", false));
     }
 }

--- a/tests/GettersTest.php
+++ b/tests/GettersTest.php
@@ -61,6 +61,7 @@ class GettersTest extends TestCase
     public function errorsRetrievalTest()
     {
         $this->rbv->validateMultiple(["datetime", "invalidDatetime"], RequestBodyValidator::DATE_FORMAT);
+        $this->rbv->getSingleCheckboxVal("gregergerger");
         $this->assertSame(["invalidDatetime"], $this->rbv->getFieldsWithErrors());
     }
 

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -46,6 +46,7 @@ class ValidatorTest extends TestCase
                 "numeric1" => "27.5",
                 "text" => "lorem",
                 "checkboxPresentValue" => true,
+                "zero" => "0"
             ]
         );
         $this->rbv = new RequestBodyValidator($request);
@@ -67,6 +68,7 @@ class ValidatorTest extends TestCase
     public function nonEmptyTest(){
         $this->assertEquals(true, $this->rbv->validateOne("nonEmpty", RequestBodyValidator::NOT_EMPTY));
         $this->assertEquals(false, $this->rbv->validateOne("empty", RequestBodyValidator::NOT_EMPTY));
+        $this->assertEquals(true, $this->rbv->validateOne("zero", RequestBodyValidator::NOT_EMPTY));
     }
 
     /**

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -56,7 +56,8 @@ class ValidatorTest extends TestCase
      * Tests the exists validator.
      * @test
      */
-    public function existTest(){
+    public function existTest()
+    {
         $this->assertEquals(true, $this->rbv->validateOne("datetime", RequestBodyValidator::EXISTS));
         $this->assertEquals(false, $this->rbv->validateOne("404-notfound", RequestBodyValidator::EXISTS));
     }
@@ -65,7 +66,8 @@ class ValidatorTest extends TestCase
      * Tests the non empty validator.
      * @test
      */
-    public function nonEmptyTest(){
+    public function nonEmptyTest()
+    {
         $this->assertEquals(true, $this->rbv->validateOne("nonEmpty", RequestBodyValidator::NOT_EMPTY));
         $this->assertEquals(false, $this->rbv->validateOne("empty", RequestBodyValidator::NOT_EMPTY));
         $this->assertEquals(true, $this->rbv->validateOne("zero", RequestBodyValidator::NOT_EMPTY));
@@ -75,7 +77,8 @@ class ValidatorTest extends TestCase
      * Tests the numeric validator.
      * @test
      */
-    public function numericTest(){
+    public function numericTest()
+    {
         $this->assertEquals(true, $this->rbv->validateOne("numeric0", RequestBodyValidator::NUMERIC));
         $this->assertEquals(true, $this->rbv->validateOne("numeric1", RequestBodyValidator::NUMERIC));
         $this->assertEquals(false, $this->rbv->validateOne("text", RequestBodyValidator::NUMERIC));
@@ -85,7 +88,8 @@ class ValidatorTest extends TestCase
      * Tests the not numeric validator.
      * @test
      */
-    public function notNumericTest(){
+    public function notNumericTest()
+    {
         $this->assertEquals(false, $this->rbv->validateOne("numeric0", RequestBodyValidator::NOT_NUMERIC));
         $this->assertEquals(false, $this->rbv->validateOne("numeric1", RequestBodyValidator::NOT_NUMERIC));
         $this->assertEquals(true, $this->rbv->validateOne("text", RequestBodyValidator::NOT_NUMERIC));
@@ -95,7 +99,8 @@ class ValidatorTest extends TestCase
      * Tests the date format validator.
      * @test
      */
-    public function dateFormatTest(){
+    public function dateFormatTest()
+    {
         $this->assertEquals(true, $this->rbv->validateOne("datetime", RequestBodyValidator::DATE_FORMAT));
         $this->assertEquals(false, $this->rbv->validateOne("invalidDatetime", RequestBodyValidator::DATE_FORMAT));
     }


### PR DESCRIPTION
- Added a method to retrieve non-empty strings only
- Type-coercion safe Getters test
- Corrected incorrect validation failure for retrieved fields
- Changed behaviour of `getDateTime` to match the behaviour of other methods
    - Does not trigger a fatal error if the field does not exist
- `0` is not considered as empty anymore